### PR TITLE
Home page additions

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,36 +123,42 @@
 
     <div class="container">
         <div class="hero pt-5 pb-4 text-center">
-            <div class="text-center">
+            <div class="text-start">
                 <img src="https://docs.dotkernel.org/img/dk_logo_2024.svg" alt="Dotkernel logo with text" />
-                <h1 class="fw-bold py-3 m-0">A Full-Fledged Headless Platform</h1>
-            </div>
-            <ul class="text-start list-unstyled">
-                <li>
-                    <i class="bi bi-check text-success"></i>
-                    Built on top of the Mezzio microframework using Laminas components.
-                </li>
-                <li>
-                    <i class="bi bi-check text-success"></i>
-                    With both <a href="https://github.com/dotkernel/admin" target="_blank">backend management</a> and <a href="https://github.com/dotkernel/api" target="_blank">frontend-agnostic capabilities.</a>
-                </li>
-                <li>
-                    <i class="bi bi-check text-success"></i>
-                    Built entirely on PSR-15 middleware.
-                </li>
-                <li>
-                    <i class="bi bi-check text-success"></i>
-                    Follows the middleware pipeline pattern offered by Laminas and the PSR standards.
-                </li>
-                <li>
-                    <i class="bi bi-check text-success"></i>
-                    Adhering strictly to <a href="https://www.php-fig.org/psr/psr-3/" target="_blank">PSR-3</a> (<a href="https://github.com/php-fig/log" target="_blank">logging</a>), <a href="https://www.php-fig.org/psr/psr-7/" target="_blank">PSR-7</a> (<a href="https://github.com/php-fig/http-message" target="_blank">HTTP messages</a>), <a href="https://www.php-fig.org/psr/psr-11/" target="_blank">PSR-11</a> (<a href="https://github.com/php-fig/container" target="_blank">containers</a>), <a href="https://github.com/php-fig/http-server-handler" target="_blank">PSR-15</a> (<a href="https://github.com/php-fig/http-server-handler" target="_blank">middleware</a>).
-                </li>
-            </ul>
-            <div class="text-center">
-                <h5>Open discussions are available on
-                    <a href="https://github.com/orgs/dotkernel/discussions" target="_blank">our GitHub Discussions page</a>
-                </h5>
+                <h1 class="fw-bold py-3 m-0">
+                    A Full-Fledged Headless Platform
+                </h1>
+                <ul class="list-unstyled">
+                    <li>
+                        <i class="bi bi-check text-success"></i>
+                        Built on top of the Mezzio microframework using Laminas components.
+                    </li>
+                    <li>
+                        <i class="bi bi-check text-success"></i>
+                        With both <a href="https://github.com/dotkernel/admin" target="_blank">backend management</a>
+                        and <a href="https://github.com/dotkernel/api" target="_blank">frontend-agnostic capabilities.</a>
+                    </li>
+                    <li>
+                        <i class="bi bi-check text-success"></i>
+                        Built entirely on PSR-15 middleware.
+                    </li>
+                    <li>
+                        <i class="bi bi-check text-success"></i>
+                        Follows the middleware pipeline pattern offered by Laminas and the PSR standards.
+                    </li>
+                    <li>
+                        <i class="bi bi-check text-success"></i>
+                        Adhering strictly to
+                        <a href="https://www.php-fig.org/psr/psr-3/" target="_blank">PSR-3</a> (<a href="https://github.com/php-fig/log" target="_blank">logging</a>),
+                        <a href="https://www.php-fig.org/psr/psr-7/" target="_blank">PSR-7</a> (<a href="https://github.com/php-fig/http-message" target="_blank">HTTP messages</a>),
+                        <a href="https://www.php-fig.org/psr/psr-11/" target="_blank">PSR-11</a> (<a href="https://github.com/php-fig/container" target="_blank">containers</a>),
+                        <a href="https://www.php-fig.org/psr/psr-15/" target="_blank">PSR-15</a> (<a href="https://github.com/php-fig/http-server-handler" target="_blank">middleware</a>).
+                    </li>
+                </ul>
+                <p>
+                    Open discussions are available on our
+                    <a href="https://github.com/orgs/dotkernel/discussions" target="_blank">GitHub Discussions page</a>
+                </p>
             </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -31,80 +31,72 @@
                         <ul class="dropdown-menu">
                             <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/api-documentation/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">API</span>
-                                        <span>Dotkernel API</span>
                                     </div>
                                 </a>
                             </li>
 
                             <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/admin-documentation/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">Admin</span>
-                                        <span>Dotkernel Admin application</span>
                                     </div>
                                 </a>
                             </li>
 
                             <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/frontend-documentation/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">Frontend</span>
-                                        <span>Dotkernel Frontend application</span>
                                     </div>
                                 </a>
                             </li>
 
                             <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/light-documentation/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">Light</span>
-                                        <span>Dotkernel Light application</span>
                                     </div>
                                 </a>
                             </li>
 
                             <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/queue-documentation/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">Queue</span>
-                                        <span>Dotkernel Queue application</span>
                                     </div>
                                 </a>
                             </li>
 
                             <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/headless-documentation/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">Headless Platform</span>
-                                        <span>Dotkernel Headless Platform</span>
                                     </div>
                                 </a>
                             </li>
 
                             <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/packages/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">Packages</span>
-                                        <span>Dotkernel packages</span>
                                     </div>
                                 </a>
                             </li>
 
                             <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/development/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">Development</span>
-                                        <span>WSL2 Development Environment</span>
                                     </div>
                                 </a>
                             </li>
@@ -130,13 +122,47 @@
     </nav>
 
     <div class="container">
-        <div class="hero py-5 text-center">
-            <h1 class="fw-bold">Dotkernel documentation</h1>
+        <div class="hero pt-5 pb-4 text-center">
+            <div class="text-center">
+                <img src="https://docs.dotkernel.org/img/dk_logo_2024.svg" alt="Dotkernel logo with text" />
+                <h1 class="fw-bold py-3 m-0">A Full-Fledged Headless Platform</h1>
+            </div>
+            <ul class="text-start list-unstyled">
+                <li>
+                    <i class="bi bi-check text-success"></i>
+                    Built on top of the Mezzio microframework using Laminas components.
+                </li>
+                <li>
+                    <i class="bi bi-check text-success"></i>
+                    With both <a href="https://github.com/dotkernel/admin" target="_blank">backend management</a> and <a href="https://github.com/dotkernel/api" target="_blank">frontend-agnostic capabilities.</a>
+                </li>
+                <li>
+                    <i class="bi bi-check text-success"></i>
+                    Built entirely on PSR-15 middleware.
+                </li>
+                <li>
+                    <i class="bi bi-check text-success"></i>
+                    Follows the middleware pipeline pattern offered by Laminas and the PSR standards.
+                </li>
+                <li>
+                    <i class="bi bi-check text-success"></i>
+                    Adhering strictly to <a href="https://www.php-fig.org/psr/psr-3/" target="_blank">PSR-3</a> (<a href="https://github.com/php-fig/log" target="_blank">logging</a>), <a href="https://www.php-fig.org/psr/psr-7/" target="_blank">PSR-7</a> (<a href="https://github.com/php-fig/http-message" target="_blank">HTTP messages</a>), <a href="https://www.php-fig.org/psr/psr-11/" target="_blank">PSR-11</a> (<a href="https://github.com/php-fig/container" target="_blank">containers</a>), <a href="https://github.com/php-fig/http-server-handler" target="_blank">PSR-15</a> (<a href="https://github.com/php-fig/http-server-handler" target="_blank">middleware</a>).
+                </li>
+            </ul>
+            <div class="text-center">
+                <h5>Open discussions are available on
+                    <a href="https://github.com/orgs/dotkernel/discussions" target="_blank">our GitHub Discussions page</a>
+                </h5>
+            </div>
+        </div>
+
+        <div class="text-center">
+            <h2 class="fw-bold">Dotkernel documentation</h2>
         </div>
 
         <div class="main">
             <div class="row gx-4 gy-1">
-                <div class="col-lg-4 col-md-6 py-2">
+                <div class="col-lg-3 col-md-6 col-sm-12 py-2">
                     <div class="card h-100 pkg_card">
                         <div class="card-header">
                             <a href="https://docs.dotkernel.org/admin-documentation/" class="stretched-link">
@@ -150,7 +176,7 @@
                     </div>
                 </div>
 
-                <div class="col-lg-4 col-md-6 py-2">
+                <div class="col-lg-3 col-md-6 col-sm-12 py-2">
                     <div class="card h-100 pkg_card">
                         <div class="card-header">
                             <a href="https://docs.dotkernel.org/frontend-documentation/" class="stretched-link">
@@ -164,7 +190,7 @@
                     </div>
                 </div>
 
-                <div class="col-lg-4 col-md-6 py-2">
+                <div class="col-lg-3 col-md-6 col-sm-12 py-2">
                     <div class="card h-100 pkg_card">
                         <div class="card-header">
                             <a href="https://docs.dotkernel.org/light-documentation/" class="stretched-link">
@@ -178,7 +204,7 @@
                     </div>
                 </div>
 
-                <div class="col-lg-3 col-md-6 py-2">
+                <div class="col-lg-3 col-md-6 col-sm-12 py-2">
                     <div class="card h-100 pkg_card">
                         <div class="card-header">
                             <a href="https://docs.dotkernel.org/headless-documentation/" class="stretched-link">
@@ -192,7 +218,7 @@
                     </div>
                 </div>
 
-                <div class="col-lg-6 col-md-6 py-2">
+                <div class="col-lg-3 col-md-6 col-sm-12 py-2">
                     <div class="card h-100 pkg_card">
                         <div class="card-header">
                             <a href="https://docs.dotkernel.org/api-documentation/" class="stretched-link">
@@ -206,7 +232,7 @@
                     </div>
                 </div>
 
-                <div class="col-lg-3 col-md-6 py-2">
+                <div class="col-lg-3 col-md-6 col-sm-12 py-2">
                     <div class="card h-100 pkg_card">
                         <div class="card-header">
                             <a href="https://docs.dotkernel.org/queue-documentation/" class="stretched-link">
@@ -220,7 +246,7 @@
                     </div>
                 </div>
 
-                <div class="col-lg-6 col-md-6 py-2">
+                <div class="col-lg-3 col-md-6 col-sm-12 py-2">
                     <div class="card h-100 pkg_card">
                         <div class="card-header">
                             <a href="https://docs.dotkernel.org/packages/" class="stretched-link">
@@ -234,15 +260,15 @@
                     </div>
                 </div>
 
-                <div class="col-lg-6 col-md-6 py-2">
+                <div class="col-lg-3 col-md-6 col-sm-12 py-2">
                     <div class="card h-100 pkg_card">
                         <div class="card-header">
                             <a href="https://docs.dotkernel.org/development/" class="stretched-link">
-                                Development environment
+                                WSL2 Development environment
                             </a>
                         </div>
                         <div class="card-body pkg_card_body">
-                            <h5 class="card-title">WSL2 Development Environment</h5>
+                            <h5 class="card-title">Development</h5>
                             <p class="card-text">Install PHP, Apache, MariaDB, Composer, PhpMyAdmin, Node.js and Git on WSL2</p>
                         </div>
                     </div>
@@ -341,6 +367,11 @@
                                 <i class="bi bi-rss-fill"></i> Feed
                             </a>
                         </li>
+                        <li class="support__list-item col-lg-6 mb-md-3">
+                            <a href="https://github.com/orgs/dotkernel/discussions" class="support__link" title="Blog feed" target="_blank">
+                                <i class="bi bi-chat-left-text"></i> Discussions
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>
@@ -348,7 +379,7 @@
             <hr class="mt-5" />
 
             <div class="footer_copy">
-                &#169; Copyright Dotkernel 2024. All rights reserved.
+                &#169; Copyright Dotkernel <span id="current-year"></span>. All rights reserved.
             </div>
         </div>
     </footer>

--- a/js/docs.js
+++ b/js/docs.js
@@ -22,4 +22,6 @@ document.addEventListener("DOMContentLoaded", function () {
         icon.setAttribute("onclick", "copy(this)");
         element.prepend(icon);
     });
+
+    document.getElementById("current-year").textContent = new Date().getFullYear().toString();
 });

--- a/packages/index.html
+++ b/packages/index.html
@@ -24,87 +24,79 @@
                 </a>
 
                 <div class="dk-nav-icon-items">
-                    <span style="font-size: 12px; line-height: 13px">Dotkernel Documentation</span>
+                    <span style="font-size: 12px; line-height: 13px">Dotkernel documentation</span>
 
                     <div class="dropdown" data-bs-theme="light">
-                        <span class="fw-bold dropdown-toggle dk-pkg-name" data-bs-toggle="dropdown" aria-expanded="false">Packages</span>
+                        <span class="fw-bold dropdown-toggle dk-pkg-name" data-bs-toggle="dropdown" aria-expanded="false">Projects</span>
                         <ul class="dropdown-menu">
                             <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/api-documentation/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">API</span>
-                                        <span>Dotkernel API</span>
                                     </div>
                                 </a>
                             </li>
 
                             <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/admin-documentation/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">Admin</span>
-                                        <span>Dotkernel Admin application</span>
                                     </div>
                                 </a>
                             </li>
 
                             <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/frontend-documentation/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">Frontend</span>
-                                        <span>Dotkernel Frontend application</span>
                                     </div>
                                 </a>
                             </li>
 
                             <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/light-documentation/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">Light</span>
-                                        <span>Dotkernel Light application</span>
                                     </div>
                                 </a>
                             </li>
 
                             <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/queue-documentation/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">Queue</span>
-                                        <span>Dotkernel Queue application</span>
                                     </div>
                                 </a>
                             </li>
 
                             <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/headless-documentation/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">Headless Platform</span>
-                                        <span>Dotkernel Headless Platform</span>
                                     </div>
                                 </a>
                             </li>
 
-                            <li class="dropdown-item bg-light">
+                            <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/packages/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">Packages</span>
-                                        <span>Dotkernel Packages</span>
                                     </div>
                                 </a>
                             </li>
 
                             <li class="dropdown-item">
                                 <a href="https://docs.dotkernel.org/development/" class="nav-link d-flex gap-4 align-items-center">
-                                    <img src="https://docs.dotkernel.org/img/dk_logomark.svg" alt="Dotkernel Logo" width="45" height="50" class="d-inline-block align-text-top" />
-                                    <div>
+                                    <i class="bi bi-arrow-return-right text-primary"></i>
+                                    <div class="py-1">
                                         <span class="fw-bold d-block">Development</span>
-                                        <span>WSL2 Development Environment</span>
                                     </div>
                                 </a>
                             </li>
@@ -635,6 +627,11 @@
                                 <i class="bi bi-rss-fill"></i> Feed
                             </a>
                         </li>
+                        <li class="support__list-item col-lg-6 mb-md-3">
+                            <a href="https://github.com/orgs/dotkernel/discussions" class="support__link" title="Blog feed" target="_blank">
+                                <i class="bi bi-chat-left-text"></i> Discussions
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>
@@ -642,7 +639,7 @@
             <hr class="mt-5" />
 
             <div class="footer_copy">
-                &#169; Copyright Dotkernel 2024. All rights reserved.
+                &#169; Copyright Dotkernel <span id="current-year"></span>. All rights reserved.
             </div>
         </div>
     </footer>


### PR DESCRIPTION
@arhimede Here are some variations, let me know which looks better or what needs to be changed:

1. Features list to the left, with bullets
<img width="1920" height="1506" alt="bullet-left" src="https://github.com/user-attachments/assets/b87f0a63-6914-4f95-a38d-5ddd469cd8bb" />

2. Features list to the left, without bullets
<img width="1920" height="1506" alt="no-bullet-left" src="https://github.com/user-attachments/assets/d34b108a-8098-4247-a9f3-c7dfdd1077c8" />

3. Features list to the center, with bullets
<img width="1920" height="1506" alt="bullet-center" src="https://github.com/user-attachments/assets/0e8e1c22-1ac0-4570-a1db-c945e0888b0c" />

4. Features list to the center, without bullets
<img width="1920" height="1506" alt="no-bullet-center" src="https://github.com/user-attachments/assets/40bf8e91-ff24-4f9d-8c60-6bee6fed971c" />

---

This is the initial visible area, without scrolling:
<img width="1920" height="947" alt="visible-area" src="https://github.com/user-attachments/assets/f1aa6509-38e2-4b24-9755-5257651e7ea6" />
